### PR TITLE
Working App Engine / zc.buildout example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# IDEs, etc
+.idea

--- a/examples/appengine-buildout/.gitignore
+++ b/examples/appengine-buildout/.gitignore
@@ -1,0 +1,3 @@
+# for buildout ignores
+downloads
+src

--- a/examples/appengine-buildout/README.md
+++ b/examples/appengine-buildout/README.md
@@ -1,0 +1,19 @@
+Google App Engine + zc.buildout + Google Glass
+===
+
+## Installation
+    $ python bootstrap.py
+    $ ./bin/buildout
+
+## Configuration
+Open `config.py` and set `appname`, `client_id`, and `client_secret` to match your [Google APIs console](https://code.google.com/apis/console/) setup
+
+## Running the example
+Launch the appserver
+
+    $ ./bin/dev_appserver
+
+Point your web browser to [http://localhost:8765/](http://localhost:8765/)
+
+- Enjoy
+

--- a/examples/appengine-buildout/app/app.yaml
+++ b/examples/appengine-buildout/app/app.yaml
@@ -1,0 +1,13 @@
+application: insthu
+version: production
+runtime: python27
+api_version: 1
+threadsafe: no
+
+handlers:
+- url: /.*
+  script: main.app.web
+
+libraries:
+- name: jinja2
+  version: latest

--- a/examples/appengine-buildout/app/config.py
+++ b/examples/appengine-buildout/app/config.py
@@ -1,0 +1,3 @@
+appname = ""
+client_id = ""
+client_secret = ""

--- a/examples/appengine-buildout/app/main.py
+++ b/examples/appengine-buildout/app/main.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+# add dist to path for buildout-managed dependencies
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'dist'))
+
+import glass
+import config
+import logging
+from flask import session, render_template, redirect
+
+app = glass.Application(
+    name=config.appname,
+    client_id=config.client_id,
+    client_secret=config.client_secret)
+
+# Set the secret key for flask session.  keep this really secret: (but here it's not ;) )
+app.web.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
+
+app.prepare(port=8765)
+
+@app.web.route("/")
+def index():
+    configured = config.appname and config.client_id and config.client_secret
+    user = None
+    if 'token' in session:
+        user = glass.User(app=app, token=session['token'])
+    return render_template("index.html", user=user, configured=configured)
+
+@app.subscriptions.login
+def login(user):
+    session['token'] = user.token
+    user.timeline.post(text="Hello from App Engine!")
+    return redirect('/')

--- a/examples/appengine-buildout/app/templates/index.html
+++ b/examples/appengine-buildout/app/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Google App Engine + Buildout + Glass</title>
+        <link rel="stylesheet" href="/static/style.css">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    </head>
+    <body>
+        <h1>Google App Engine + Buildout + Google Glass</h1>
+        {% if not configured %}
+            <p>appname, client_id, and client_secret must be set in <span style="font-family: monospace">config.py</span>
+            before this example will work. Please configure =D</p>
+        {% else %}
+            {% if not user %}
+                <a href="/glass/oauth/authorize">Install it</a>
+            {% else %}
+                <p>{{ user.profile().get("given_name") }}, thank you for installing this application!</p>
+            {% endif %}
+        {% endif %}
+    </body>
+</html>

--- a/examples/appengine-buildout/bootstrap.py
+++ b/examples/appengine-buildout/bootstrap.py
@@ -1,0 +1,277 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+"""
+
+import os, shutil, sys, tempfile, urllib, urllib2, subprocess
+from optparse import OptionParser
+
+if sys.platform == 'win32':
+    def quote(c):
+        if ' ' in c:
+            return '"%s"' % c  # work around spawn lamosity on windows
+        else:
+            return c
+else:
+    quote = str
+
+# See zc.buildout.easy_install._has_broken_dash_S for motivation and comments.
+stdout, stderr = subprocess.Popen(
+    [sys.executable, '-Sc',
+     'try:\n'
+     '    import ConfigParser\n'
+     'except ImportError:\n'
+     '    print 1\n'
+     'else:\n'
+     '    print 0\n'],
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+has_broken_dash_S = bool(int(stdout.strip()))
+
+# In order to be more robust in the face of system Pythons, we want to
+# run without site-packages loaded.  This is somewhat tricky, in
+# particular because Python 2.6's distutils imports site, so starting
+# with the -S flag is not sufficient.  However, we'll start with that:
+if not has_broken_dash_S and 'site' in sys.modules:
+    # We will restart with python -S.
+    args = sys.argv[:]
+    args[0:0] = [sys.executable, '-S']
+    args = map(quote, args)
+    os.execv(sys.executable, args)
+# Now we are running with -S.  We'll get the clean sys.path, import site
+# because distutils will do it later, and then reset the path and clean
+# out any namespace packages from site-packages that might have been
+# loaded by .pth files.
+clean_path = sys.path[:]
+import site  # imported because of its side effects
+sys.path[:] = clean_path
+for k, v in sys.modules.items():
+    if k in ('setuptools', 'pkg_resources') or (
+        hasattr(v, '__path__') and
+        len(v.__path__) == 1 and
+        not os.path.exists(os.path.join(v.__path__[0], '__init__.py'))):
+        # This is a namespace package.  Remove it.
+        sys.modules.pop(k)
+
+is_jython = sys.platform.startswith('java')
+
+setuptools_source = 'http://peak.telecommunity.com/dist/ez_setup.py'
+distribute_source = 'http://python-distribute.org/distribute_setup.py'
+
+
+# parsing arguments
+def normalize_to_url(option, opt_str, value, parser):
+    if value:
+        if '://' not in value:  # It doesn't smell like a URL.
+            value = 'file://%s' % (
+                urllib.pathname2url(
+                    os.path.abspath(os.path.expanduser(value))),)
+        if opt_str == '--download-base' and not value.endswith('/'):
+            # Download base needs a trailing slash to make the world happy.
+            value += '/'
+    else:
+        value = None
+    name = opt_str[2:].replace('-', '_')
+    setattr(parser.values, name, value)
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --setup-source and --download-base to point to
+local resources, you can keep this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", dest="version",
+                          help="use a specific zc.buildout version")
+parser.add_option("-d", "--distribute",
+                   action="store_true", dest="use_distribute", default=False,
+                   help="Use Distribute rather than Setuptools.")
+parser.add_option("--setup-source", action="callback", dest="setup_source",
+                  callback=normalize_to_url, nargs=1, type="string",
+                  help=("Specify a URL or file location for the setup file. "
+                        "If you use Setuptools, this will default to " +
+                        setuptools_source + "; if you use Distribute, this "
+                        "will default to " + distribute_source + "."))
+parser.add_option("--download-base", action="callback", dest="download_base",
+                  callback=normalize_to_url, nargs=1, type="string",
+                  help=("Specify a URL or directory for downloading "
+                        "zc.buildout and either Setuptools or Distribute. "
+                        "Defaults to PyPI."))
+parser.add_option("--eggs",
+                  help=("Specify a directory for storing eggs.  Defaults to "
+                        "a temporary directory that is deleted when the "
+                        "bootstrap script completes."))
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", None, action="store", dest="config_file",
+                   help=("Specify the path to the buildout configuration "
+                         "file to be used."))
+
+options, args = parser.parse_args()
+
+if options.eggs:
+    eggs_dir = os.path.abspath(os.path.expanduser(options.eggs))
+else:
+    eggs_dir = tempfile.mkdtemp()
+
+if options.setup_source is None:
+    if options.use_distribute:
+        options.setup_source = distribute_source
+    else:
+        options.setup_source = setuptools_source
+
+if options.accept_buildout_test_releases:
+    args.insert(0, 'buildout:accept-buildout-test-releases=true')
+
+try:
+    import pkg_resources
+    import setuptools  # A flag.  Sometimes pkg_resources is installed alone.
+    if not hasattr(pkg_resources, '_distribute'):
+        raise ImportError
+except ImportError:
+    ez_code = urllib2.urlopen(
+        options.setup_source).read().replace('\r\n', '\n')
+    ez = {}
+    exec ez_code in ez
+    setup_args = dict(to_dir=eggs_dir, download_delay=0)
+    if options.download_base:
+        setup_args['download_base'] = options.download_base
+    if options.use_distribute:
+        setup_args['no_fake'] = True
+        if sys.version_info[:2] == (2, 4):
+            setup_args['version'] = '0.6.32'
+    ez['use_setuptools'](**setup_args)
+    if 'pkg_resources' in sys.modules:
+        reload(sys.modules['pkg_resources'])
+    import pkg_resources
+    # This does not (always?) update the default working set.  We will
+    # do it.
+    for path in sys.path:
+        if path not in pkg_resources.working_set.entries:
+            pkg_resources.working_set.add_entry(path)
+
+cmd = [quote(sys.executable),
+       '-c',
+       quote('from setuptools.command.easy_install import main; main()'),
+       '-mqNxd',
+       quote(eggs_dir)]
+
+if not has_broken_dash_S:
+    cmd.insert(1, '-S')
+
+find_links = options.download_base
+if not find_links:
+    find_links = os.environ.get('bootstrap-testing-find-links')
+if not find_links and options.accept_buildout_test_releases:
+    find_links = 'http://downloads.buildout.org/'
+if find_links:
+    cmd.extend(['-f', quote(find_links)])
+
+if options.use_distribute:
+    setup_requirement = 'distribute'
+else:
+    setup_requirement = 'setuptools'
+ws = pkg_resources.working_set
+setup_requirement_path = ws.find(
+    pkg_resources.Requirement.parse(setup_requirement)).location
+env = dict(
+    os.environ,
+    PYTHONPATH=setup_requirement_path)
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setup_requirement_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if distv >= pkg_resources.parse_version('2dev'):
+                continue
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+
+if version:
+    requirement += '=='+version
+else:
+    requirement += '<2dev'
+
+cmd.append(requirement)
+
+if is_jython:
+    import subprocess
+    exitcode = subprocess.Popen(cmd, env=env).wait()
+else:  # Windows prefers this, apparently; otherwise we would prefer subprocess
+    exitcode = os.spawnle(*([os.P_WAIT, sys.executable] + cmd + [env]))
+if exitcode != 0:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    print ("An error occurred when trying to install zc.buildout. "
+           "Look above this message for any errors that "
+           "were output by easy_install.")
+    sys.exit(exitcode)
+
+ws.add_entry(eggs_dir)
+ws.require(requirement)
+import zc.buildout.buildout
+
+# If there isn't already a command in the args, add bootstrap
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+
+# if -c was provided, we push it back into args for buildout's main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
+if not options.eggs:  # clean up temporary egg directory
+    shutil.rmtree(eggs_dir)

--- a/examples/appengine-buildout/buildout.cfg
+++ b/examples/appengine-buildout/buildout.cfg
@@ -1,0 +1,73 @@
+[buildout]
+extensions = mr.developer
+include-site-packages=false
+auto-checkout =
+    glass.py
+develop =
+parts =
+    python
+    gae_sdk
+    gae_tools
+    app_lib
+
+[sources]
+glass.py = git git@github.com:SamyPesse/glass.py.git branch=master update=true
+
+[app_lib_base]
+recipe = appfy.recipe.gae:app_lib
+use-zipimport = false
+
+# Generate relative paths for eggs so that the buildout can be moved around.
+relative-paths = true
+
+# Unzip eggs automatically, if needed.
+unzip = true
+
+# Don't copy files that match these glob patterns.
+ignore-globs =
+    *.c
+    *.pyc
+    *.pyo
+
+# Don't install these packages or modules.
+ignore-packages =
+    distribute
+    setuptools
+    easy_install
+    site
+    pkg_resources
+
+[app_lib]
+<= app_lib_base
+# Sets the library dependencies for the app.
+lib-directory = app/dist
+# Define the libraries.
+eggs =
+    glass.py
+    Flask
+    rauth
+    requests
+    Jinja2
+
+[python]
+recipe = zc.recipe.egg
+interpreter = python
+eggs =
+    ${app_lib:eggs}
+
+[gae_sdk]
+# Downloads and extracts the App Engine SDK.
+recipe = appfy.recipe.gae:sdk
+url = http://googleappengine.googlecode.com/files/google_appengine_1.8.4.zip
+destination = ${buildout:parts-directory}
+hash-name = false
+clear-destination = true
+
+[gae_tools]
+# Installs appcfg, dev_appserver and python executables in the bin directory.
+recipe = appfy.recipe.gae:tools
+sdk-directory = ${gae_sdk:destination}/google_appengine
+
+# Add these paths to sys.path in the generated scripts.
+extra-paths =
+    ${buildout:directory}/app/dist

--- a/examples/appengine-buildout/gaetools.cfg
+++ b/examples/appengine-buildout/gaetools.cfg
@@ -1,0 +1,11 @@
+[dev_appserver]
+# Set default values to start the dev_appserver. All options from the
+# command line are allowed. They are inserted at the beginning of the
+# arguments. Values are used as they are; don't use variables here.
+recipe = appfy.recipe.gae:tools
+defaults =
+    --port=8765
+    --admin_port=8766
+    --host=0.0.0.0
+    --skip_sdk_update_check=True
+    app


### PR DESCRIPTION
This PR adds a new example folder for anyone trying to run this app on Google App Engine using zc.buildout to manage dependencies. The README.md file contains the instructions on how to launch and test
